### PR TITLE
refine permutation importance plot

### DIFF
--- a/sreftml/plots.py
+++ b/sreftml/plots.py
@@ -598,6 +598,7 @@ def permutation_importance_plot(
     mean_pi: np.ndarray,
     std_pi: np.ndarray,
     feature_label: list[str],
+    y_axis_log: bool = False,
     save_file_path: str | None = None,
 ) -> plt.Figure:
     """
@@ -607,15 +608,21 @@ def permutation_importance_plot(
         mean_pi (np.ndarray): Array of mean permutation importance values.
         std_pi (np.ndarray): Array of standard deviation permutation importance values.
         feature_label (list[str]): List of feature names for which PI was measured.
+        y_axis_log (bool, optional): Whether to use log scale for y-axis. Default is False.
         save_file_path (str, optional): The path where the plot will be saved. Default to None.
 
     Returns:
         plt.Figure: The plotted figure.
     """
     rank = np.argsort(mean_pi)
-    fig = plt.figure(figsize=(4, len(rank) / 4), dpi=300, tight_layout=True)
-    plt.barh([feature_label[i] for i in rank], mean_pi[rank], xerr=std_pi[rank])
-    plt.xlabel("Permutation Importance")
+    fig = plt.figure(figsize=(len(rank) / 4, 10), dpi=300, tight_layout=True)
+    plt.bar([feature_label[i] for i in rank], mean_pi[rank], yerr=std_pi[rank])
+    plt.xticks(rotation=45, ha="right")
+    if y_axis_log:
+        plt.ylabel("Permutation Importance (log scale)")
+        plt.yscale("log")
+    else:
+        plt.ylabel("Permutation Importance")
 
     if save_file_path is not None:
         plt.savefig(save_file_path, transparent=True)


### PR DESCRIPTION
I propose this modification because the previous plots were difficult to see, especially when the number of biomarkers is large.

- Invert x- and y-axes
- Add option to make y-axis log
- adjust plot size

After applying this modification, the plot should look like this.
![230830122722_permutation_importance](https://github.com/RyotaJin/sreft-ml/assets/19750475/bcb776af-e54d-4bc1-b280-732cf7cd8179)

