### PR TITLE
fix slope calculation for single time point

### DIFF
--- a/sreftml/utilities.py
+++ b/sreftml/utilities.py
@@ -11,8 +11,6 @@ from sklearn.linear_model import LinearRegression
 
 
 class NullModel:
-    params = [np.nan, np.nan]
-
     def __init__(self, Intercept, TIME):
         self.params = [Intercept, TIME]
 


### PR DESCRIPTION
- Previously, slope and intercept could not be calculated when there was only one measurement point in the data.
- With this change, when there is only one data point, the original data is assigned to intercept and intercept is not used.